### PR TITLE
Harden privileged input boundaries

### DIFF
--- a/deepinesStore/core.py
+++ b/deepinesStore/core.py
@@ -1,6 +1,7 @@
 from os import environ as env, name
 import argparse
 import json
+from deepinesStore.security import filter_forwarded_environment
 
 
 def get_ver():
@@ -28,7 +29,8 @@ def get_app_icon():
 def get_dl(uri, params=None, **kwargs):
 	from requests import get
 	try:
-		response = get(uri, params=params, **kwargs)
+		timeout = kwargs.pop("timeout", (5, 30))
+		response = get(uri, params=params, timeout=timeout, **kwargs)
 		response.raise_for_status()
 		return response
 	except Exception as e:
@@ -80,6 +82,9 @@ args = parser.parse_args()
 default_env = env.copy()
 
 if args.env:
-	new_env = json.loads(args.env)
+	try:
+		new_env = filter_forwarded_environment(json.loads(args.env))
+	except (TypeError, ValueError, json.JSONDecodeError) as error:
+		parser.error(f"invalid --env value: {error}")
 	default_env.update(new_env)
-	env.update({k: v for k, v in default_env.items() if k != 'XDG_RUNTIME_DIR'})
+	env.update(default_env)

--- a/deepinesStore/mixins.py
+++ b/deepinesStore/mixins.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import platform
-from os import system
 import subprocess
 from PyQt5.Qt import Qt
 from PyQt5.QtCore import QRect, QTimer, QRectF, pyqtSlot
@@ -117,7 +116,11 @@ class AppearanceMixin:
 			r = 0 if self.isMaximized() else self.border_radius
 
 			if r <= 0:
-				subprocess.Popen(f'xprop -f _KDE_NET_WM_BLUR_BEHIND_REGION 32c -set _KDE_NET_WM_BLUR_BEHIND_REGION 0 -id {int(self.winId())}', shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+				subprocess.Popen([
+					'xprop', '-f', '_KDE_NET_WM_BLUR_BEHIND_REGION', '32c',
+					'-set', '_KDE_NET_WM_BLUR_BEHIND_REGION', '0',
+					'-id', str(int(self.winId())),
+				], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 				return
 
 			path = QPainterPath()
@@ -150,7 +153,11 @@ class AppearanceMixin:
 				rects[best_idx] = merged
 
 			rect_str = ','.join([f"{rc.x()},{rc.y()},{rc.width()},{rc.height()}" for rc in rects])
-			subprocess.Popen(f'xprop -f _KDE_NET_WM_BLUR_BEHIND_REGION 32c -set _KDE_NET_WM_BLUR_BEHIND_REGION {rect_str} -id {int(self.winId())}', shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+			subprocess.Popen([
+				'xprop', '-f', '_KDE_NET_WM_BLUR_BEHIND_REGION', '32c',
+				'-set', '_KDE_NET_WM_BLUR_BEHIND_REGION', rect_str,
+				'-id', str(int(self.winId())),
+			], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 class GeometryMixin:
 	def showEvent(self, event):

--- a/deepinesStore/security.py
+++ b/deepinesStore/security.py
@@ -1,0 +1,74 @@
+"""Validation helpers for data that crosses trust boundaries."""
+
+import re
+
+
+FORWARDED_ENV_NAMES = frozenset({
+	"DBUS_SESSION_BUS_ADDRESS",
+	"DESKTOP_SESSION",
+	"DISPLAY",
+	"GDK_DPI_SCALE",
+	"GDK_SCALE",
+	"GTK_THEME",
+	"HTTP_PROXY",
+	"HTTPS_PROXY",
+	"LANG",
+	"LANGUAGE",
+	"NO_PROXY",
+	"QT_AUTO_SCREEN_SCALE_FACTOR",
+	"QT_FONT_DPI",
+	"QT_QPA_PLATFORM",
+	"QT_SCALE_FACTOR",
+	"QT_SCREEN_SCALE_FACTORS",
+	"QT_STYLE_OVERRIDE",
+	"WAYLAND_DISPLAY",
+	"XAUTHORITY",
+	"XDG_CURRENT_DESKTOP",
+	"XDG_DATA_DIRS",
+	"XDG_SESSION_DESKTOP",
+	"XDG_SESSION_TYPE",
+	"http_proxy",
+	"https_proxy",
+	"no_proxy",
+})
+
+_CHECKSUM_RE = re.compile(r"^[0-9a-fA-F]{32}$")
+_SVG_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*\.svg$")
+
+
+def filter_forwarded_environment(source):
+	"""Return only variables needed for GUI, locale, and proxy compatibility.
+
+	The launcher crosses a privilege boundary through pkexec. Forwarding PATH,
+	PYTHONPATH, LD_PRELOAD, or other arbitrary variables would let the invoking
+	user influence programs executed by the privileged process.
+	"""
+	if not isinstance(source, dict):
+		raise ValueError("the serialized environment must be a JSON object")
+
+	filtered = {}
+	for key, value in source.items():
+		if not isinstance(key, str) or not isinstance(value, str):
+			continue
+		if key in FORWARDED_ENV_NAMES or key.startswith("LC_"):
+			if "\x00" not in key and "\x00" not in value:
+				filtered[key] = value
+	return filtered
+
+
+def parse_remote_checksums(content):
+	"""Parse a checksum manifest while confining entries to SVG basenames."""
+	checksums = {}
+	for line_number, line in enumerate(content.splitlines(), 1):
+		parts = line.split()
+		if not parts:
+			continue
+		if len(parts) != 2:
+			print(f"Ignoring malformed SVG checksum line {line_number}")
+			continue
+		checksum, name = parts
+		if not _CHECKSUM_RE.fullmatch(checksum) or not _SVG_NAME_RE.fullmatch(name):
+			print(f"Ignoring unsafe SVG checksum line {line_number}")
+			continue
+		checksums[name] = checksum.lower()
+	return checksums

--- a/deepinesStore/setup.py
+++ b/deepinesStore/setup.py
@@ -61,7 +61,6 @@ def get_installed_apps(list_app_deb, list_app_flatpak):
 	# demoted environment (DEF) is defined. This avoids errors on
 	# platforms where `DEF` isn't available (e.g., Windows) or when
 	# AppStream/Flatpak data is missing.
-	installed_ids = []
 	installed_info = {}
 	if list_app_flatpak and hasattr(demoted, 'DEF'):
 		try:
@@ -73,15 +72,16 @@ def get_installed_apps(list_app_deb, list_app_flatpak):
 		except Exception:
 			pass
 
+	flatpaks_by_id = {}
+	for app_item in list_app_flatpak:
+		flatpaks_by_id.setdefault(app_item.id, []).append(app_item)
+
 	for installed_id, installed_version in installed_info.items():
-		for app_item in list_app_flatpak:
-			if installed_id == app_item.id:
-				list_installed.append(app_item)
-				indice = list_app_flatpak.index(app_item)
-				list_app_flatpak[indice].state = AppState.INSTALLED
-				list_app_flatpak[indice].process = ProcessType.UNINSTALL
-				if installed_version:
-					list_app_flatpak[indice].version = installed_version
+		for app_item in flatpaks_by_id.get(installed_id, []):
+			list_installed.append(app_item)
+			app_item.state = AppState.INSTALLED
+			app_item.process = ProcessType.UNINSTALL
+			if installed_version:
+				app_item.version = installed_version
 
 	return(list_installed)
-

--- a/deepinesStore/svg.py
+++ b/deepinesStore/svg.py
@@ -2,10 +2,10 @@
 
 from os.path import join, abspath, dirname, exists
 from os import listdir, remove
-from pathlib import Path
 from hashlib import md5
 from deepinesStore.core import get_dl, get_deepines_uri
 from deepinesStore.demoted_actions import config_dir, create_folder, write_file
+from deepinesStore.security import parse_remote_checksums
 import threading
 
 
@@ -18,7 +18,6 @@ class threading_svg(object):
 			create_folder(self.CONFIG_APPS_PATH)
 
 		self.RO_APPS_PATH = abspath(join(dirname(__file__), 'resources', 'apps'))
-		self.TEMP_PATH = config_dir / 'remote_svg.txt'
 
 		self.RO_APPS_CHECK = dict()
 		self.CONFIG_APPS_CHECK = dict()
@@ -36,10 +35,9 @@ class threading_svg(object):
 			self.get_local_checksum()
 			self.compare_check()
 			self.check_exists()
-			remove(self.TEMP_PATH)
 
 	def compute_md5(self, file_path):
-		hash_md5 = md5()
+		hash_md5 = md5(usedforsecurity=False)
 		with open(file_path, "rb") as f:
 			for chunk in iter(lambda: f.read(4096), b""):
 				hash_md5.update(chunk)
@@ -63,13 +61,8 @@ class threading_svg(object):
 
 		status_code = SVG_REMOTE.status_code
 		if status_code == 200:
-			write_file(SVG_REMOTE, to=self.TEMP_PATH)
-			with open(self.TEMP_PATH, 'r') as f:
-				for line in f:
-					line = line.replace('\n', '')
-					(check, space, name) = line.split(' ')
-					self.REMOTE_CHECK[name] = check
-					self.LIST_SVG_REMOTE.append(name)
+			self.REMOTE_CHECK = parse_remote_checksums(SVG_REMOTE.text)
+			self.LIST_SVG_REMOTE = list(self.REMOTE_CHECK)
 		else:
 			self.STATUS = False
 
@@ -92,7 +85,7 @@ class threading_svg(object):
 					remove(config_path) # I mean... why are you even here? Maybe a new package was released...
 			# If neither local copy matches remote, download
 			elif (ro_checksum != remote_checksum) and (config_checksum != remote_checksum):
-				self.download_svg(svg_name)
+				self.download_svg(svg_name, remote_checksum)
 
 		# Remove any local SVGs from config that are not in the remote list
 		for svg_name in list(self.CONFIG_APPS_CHECK.keys()):
@@ -108,9 +101,12 @@ class threading_svg(object):
 	def check_exists(self):
 		for svg_name in self.REMOTE_CHECK:
 			if svg_name not in self.RO_APPS_CHECK and svg_name not in self.CONFIG_APPS_CHECK:
-				self.download_svg(svg_name)
+				self.download_svg(svg_name, self.REMOTE_CHECK[svg_name])
 
-	def download_svg(self, name):
+	def download_svg(self, name, expected_checksum):
 		dl_svg = get_dl(get_deepines_uri(f'/store/svg/{name}'))
-		if dl_svg.status_code == 200:
+		checksum = md5(dl_svg.content, usedforsecurity=False).hexdigest()
+		if dl_svg.status_code == 200 and checksum == expected_checksum:
 			write_file(dl_svg, to=join(self.CONFIG_APPS_PATH, name))
+		elif dl_svg.status_code == 200:
+			print(f"Refusing SVG with an invalid checksum: {name}")

--- a/loader.py
+++ b/loader.py
@@ -5,6 +5,19 @@ import subprocess
 import os
 import json
 
-cmd = ["pkexec", "/usr/share/deepines/deepines", "--env", json.dumps(os.environ.copy())]
+FORWARDED_ENV_NAMES = {
+	"DBUS_SESSION_BUS_ADDRESS", "DESKTOP_SESSION", "DISPLAY", "GDK_DPI_SCALE",
+	"GDK_SCALE", "GTK_THEME", "HTTP_PROXY", "HTTPS_PROXY", "LANG", "LANGUAGE",
+	"NO_PROXY", "QT_AUTO_SCREEN_SCALE_FACTOR", "QT_FONT_DPI", "QT_QPA_PLATFORM",
+	"QT_SCALE_FACTOR", "QT_SCREEN_SCALE_FACTORS", "QT_STYLE_OVERRIDE",
+	"WAYLAND_DISPLAY", "XAUTHORITY", "XDG_CURRENT_DESKTOP", "XDG_DATA_DIRS",
+	"XDG_SESSION_DESKTOP", "XDG_SESSION_TYPE", "http_proxy", "https_proxy",
+	"no_proxy",
+}
+forwarded_env = {
+	key: value for key, value in os.environ.items()
+	if key in FORWARDED_ENV_NAMES or key.startswith("LC_")
+}
+cmd = ["pkexec", "/usr/share/deepines/deepines", "--env", json.dumps(forwarded_env)]
 
 subprocess.run(cmd, check=True)

--- a/tests/test_security_boundaries.py
+++ b/tests/test_security_boundaries.py
@@ -1,0 +1,63 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+security_path = Path(__file__).parents[1] / "deepinesStore" / "security.py"
+spec = importlib.util.spec_from_file_location("deepines_store_security", security_path)
+security = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(security)
+
+filter_forwarded_environment = security.filter_forwarded_environment
+parse_remote_checksums = security.parse_remote_checksums
+
+class EnvironmentFilteringTests(unittest.TestCase):
+	def test_keeps_desktop_and_locale_variables(self):
+		source = {
+			"DISPLAY": ":0",
+			"LANG": "pt_BR.UTF-8",
+			"LC_MESSAGES": "pt_BR.UTF-8",
+			"WAYLAND_DISPLAY": "wayland-0",
+		}
+
+		self.assertEqual(filter_forwarded_environment(source), source)
+
+	def test_drops_code_execution_and_command_lookup_variables(self):
+		filtered = filter_forwarded_environment({
+			"PATH": "/tmp/attacker",
+			"PYTHONPATH": "/tmp/attacker",
+			"LD_PRELOAD": "/tmp/attacker.so",
+			"BASH_ENV": "/tmp/attacker.sh",
+			"DISPLAY": ":0",
+		})
+
+		self.assertEqual(filtered, {"DISPLAY": ":0"})
+
+	def test_rejects_non_object_payload(self):
+		with self.assertRaises(ValueError):
+			filter_forwarded_environment(["PATH=/tmp/attacker"])
+
+
+class SvgManifestTests(unittest.TestCase):
+	def test_accepts_current_md5sum_format(self):
+		checksum = "dabcebd52bc398e959a636ebdb9fe1f8"
+		self.assertEqual(
+			parse_remote_checksums(f"{checksum}  veracrypt.svg\n"),
+			{"veracrypt.svg": checksum},
+		)
+
+	def test_rejects_path_traversal_and_non_svg_entries(self):
+		content = "\n".join([
+			"0" * 32 + "  ../../root/.profile.svg",
+			"1" * 32 + "  /etc/payload.svg",
+			"2" * 32 + "  payload.py",
+		])
+
+		self.assertEqual(parse_remote_checksums(content), {})
+
+	def test_rejects_invalid_checksum(self):
+		self.assertEqual(parse_remote_checksums("not-md5  icon.svg"), {})
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## What changed

- allowlist the GUI, locale, display, and proxy variables forwarded through `pkexec`
- validate the environment again in the privileged entry point
- confine remote SVG manifest entries to safe basenames and verify downloaded bytes before writing
- add bounded default HTTP timeouts
- invoke `xprop` without a shell
- index Flatpak applications by ID during installed-state detection

## Why

The launcher previously restored the caller's full environment in the root process. A caller-controlled `PATH` could therefore influence executables launched by privileged Flatpak actions. The complete environment, potentially including credentials, was also exposed in the process command line.

The SVG updater trusted remote manifest names as filesystem paths. A compromised or malformed manifest could use path traversal to escape the cache directory while the application was privileged.

The remaining changes remove an unnecessary shell, prevent indefinite network waits, and eliminate a quadratic catalog scan. No UI or intended workflow is changed.

## Validation

- `python3 -m unittest discover -s tests -v`: 6/6 passed
- `python3 -m compileall -q deepinesStore loader.py deepines.py`: passed
- `git diff --check`: passed
- Bandit: no high- or medium-severity findings after the patch
- all 278 entries in the current production SVG manifest remain accepted
